### PR TITLE
[Frontend] Feature: Handle Microapp logs as native logs

### DIFF
--- a/frontend/app/micro-app.tsx
+++ b/frontend/app/micro-app.tsx
@@ -53,7 +53,7 @@ import { useDispatch } from "react-redux";
 
 WebBrowser.maybeCompleteAuthSession();
 
-type NativeLogLevel = "debug" | "info" | "warn" | "error";
+type NativeLogLevel = "info" | "warn" | "error";
 
 const MicroApp = () => {
   const [isScannerVisible, setScannerVisible] = useState(false);
@@ -347,17 +347,20 @@ const MicroApp = () => {
     switch (level) {
       case "info":
         console.info(
-          `[Micro App] ${message}${injectedData !== undefined ? ". " + injectedData : ""}`
+          `[Micro App] ${message}.`,
+          injectedData !== undefined ? injectedData : ""
         );
         break;
       case "warn":
         console.warn(
-          `[Micro App] ${message}${injectedData !== undefined ? ". " + injectedData : ""}`
+          `[Micro App] ${message}.`,
+          injectedData !== undefined ? injectedData : ""
         );
         break;
       case "error":
         console.error(
-          `[Micro App] ${message}${injectedData !== undefined ? ". " + injectedData : ""}`
+          `[Micro App] ${message}.`,
+          injectedData !== undefined ? injectedData : ""
         );
         break;
     }

--- a/frontend/app/micro-app.tsx
+++ b/frontend/app/micro-app.tsx
@@ -346,13 +346,19 @@ const MicroApp = () => {
 
     switch (level) {
       case "info":
-        console.info("[Micro App] ", message, ". ", injectedData);
+        console.info(
+          `[Micro App] ${message}${injectedData !== undefined ? ". " + injectedData : ""}`
+        );
         break;
       case "warn":
-        console.warn("[Micro App] ", message, ". ", injectedData);
+        console.warn(
+          `[Micro App] ${message}${injectedData !== undefined ? ". " + injectedData : ""}`
+        );
         break;
       case "error":
-        console.error("[Micro App] ", message, ". ", injectedData);
+        console.error(
+          `[Micro App] ${message}${injectedData !== undefined ? ". " + injectedData : ""}`
+        );
         break;
     }
   };

--- a/frontend/utils/bridge.ts
+++ b/frontend/utils/bridge.ts
@@ -28,6 +28,7 @@ export const TOPIC = {
   RESTORE_GOOGLE_DRIVE_BACKUP: "restore_google_drive_backup",
   GOOGLE_USER_INFO: "google_user_info",
   CHECK_GOOGLE_AUTH_STATE: "check_google_auth_state",
+  NATIVE_LOG: "native_log",
 };
 
 // JavaScript code injected into the WebView to enable communication between


### PR DESCRIPTION
### Description

This PR includes changes to allow developers developing a microapp to log messages directly into the React Native DevTooling available. On the microapp frontend, a logger class (or equivalent) is required. See an example below

```typescript
import { sendNativeLog } from "../microapp-bridge"; // bridging method to send logs

export class Logger {
  static info(message: string, data?: any) {
    sendNativeLog(message, data, "info");
  }

  static error(message: string, data?: any) {
    sendNativeLog(message, data, "error");
  }

  static warn(message: string, data?: any) {
    sendNativeLog(message, data, "warn");
  }
}
```
The bridging method should be as follows (for rich logs) or equivalent:
```typescript

type LogLevel = "error" | "warn" | "info" | "debug";

/**
 * Send a log message to the native side
 * @param message - The message to send
 * @param data - The data to send
 * @param level - The level of the log
 */
export const sendNativeLog = (
  message?: any,
  data?: any,
  level: LogLevel = "debug"
): void => {
  if (window.nativebridge && window.ReactNativeWebView) {
    const logData = JSON.stringify({
      topic: Topic.nativeLog, // "native_log"
      data: {
        message,
        data,
        level,
      },
    });
    window.ReactNativeWebView.postMessage(logData);
  } else {
    console.error("Native bridge is not available");
  }
};
```

### Screenshots
<img width="732" height="484" alt="Screenshot 2025-09-17 at 14 35 20" src="https://github.com/user-attachments/assets/efacf321-f755-455e-b50f-946cb98fcfa2" />
