### PR TITLE
Feat : Add support for closing WebView when triggered by Micro App

### DIFF
--- a/frontend/app/micro-app.tsx
+++ b/frontend/app/micro-app.tsx
@@ -328,7 +328,7 @@ const MicroApp = () => {
         case TOPIC.GOOGLE_USER_INFO:
           handleGetGoogleUserInfo();
           break;
-        case TOPIC.GO_BACK:
+        case TOPIC.CLOSE_WEBVIEW_FROM_MICROAPP:
           router.back();
           break;
         default:

--- a/frontend/app/micro-app.tsx
+++ b/frontend/app/micro-app.tsx
@@ -23,7 +23,7 @@ import {
 } from "react-native";
 import { useEffect, useRef, useState } from "react";
 import { WebView, WebViewMessageEvent } from "react-native-webview";
-import { Stack, useLocalSearchParams } from "expo-router";
+import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import NotFound from "@/components/NotFound";
 import Scanner from "@/components/Scanner";
 import { useDispatch } from "react-redux";
@@ -65,6 +65,7 @@ const MicroApp = () => {
   const webviewRef = useRef<WebView>(null);
   const [token, setToken] = useState<string | null>();
   const dispatch = useDispatch();
+  const router = useRouter();
   const pendingTokenRequests: ((token: string) => void)[] = [];
   const [webUri, setWebUri] = useState<string>(DEVELOPER_APP_DEFAULT_URL);
   const colorScheme = useColorScheme();
@@ -326,6 +327,9 @@ const MicroApp = () => {
           break;
         case TOPIC.GOOGLE_USER_INFO:
           handleGetGoogleUserInfo();
+          break;
+        case TOPIC.GO_BACK:
+          router.back();
           break;
         default:
           console.error("Unknown topic:", topic);

--- a/frontend/components/ListItem.tsx
+++ b/frontend/components/ListItem.tsx
@@ -29,6 +29,7 @@ import React from "react";
 import ActionButton from "./ActionButton";
 import { router } from "expo-router";
 import { ScreenPaths } from "@/constants/ScreenPaths";
+import { DisplayMode } from "@/types/navigation";
 
 
 type ListItemProps = {
@@ -44,7 +45,7 @@ type ListItemProps = {
   downloading: boolean;
   onDownload: () => void;
   onRemove: () => void;
-  displayMode?: typeof FULL_SCREEN_VIEWING_MODE | typeof DEFAULT_VIEWING_MODE;
+  displayMode?: DisplayMode;
 };
 
 const ListItem = React.memo(

--- a/frontend/components/Widget.tsx
+++ b/frontend/components/Widget.tsx
@@ -14,11 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 import { Colors } from "@/constants/Colors";
-import {
-  DEFAULT_VIEWING_MODE,
-  FULL_SCREEN_VIEWING_MODE,
-} from "@/constants/Constants";
 import { ScreenPaths } from "@/constants/ScreenPaths";
+import { DisplayMode } from "@/types/navigation";
 import { Image } from "expo-image";
 import { router } from "expo-router";
 import React from "react";
@@ -42,7 +39,7 @@ type WidgetProps = {
   clientId: string;
   exchangedToken: string;
   appId: string;
-  displayMode?: typeof FULL_SCREEN_VIEWING_MODE | typeof DEFAULT_VIEWING_MODE;
+  displayMode?: DisplayMode;
 };
 
 const Widget = React.memo(

--- a/frontend/context/slices/appSlice.ts
+++ b/frontend/context/slices/appSlice.ts
@@ -15,11 +15,8 @@
 // under the License.
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import {
-  APPS,
-  DEFAULT_VIEWING_MODE,
-  FULL_SCREEN_VIEWING_MODE,
-} from "@/constants/Constants";
+import { APPS, DEFAULT_VIEWING_MODE } from "@/constants/Constants";
+import { DisplayMode } from "@/types/navigation";
 
 export type Version = {
   version: string;
@@ -42,7 +39,7 @@ export type MicroApp = {
   webViewUri?: string | "";
   clientId?: string | "";
   exchangedToken?: string | "";
-  displayMode?: typeof FULL_SCREEN_VIEWING_MODE | typeof DEFAULT_VIEWING_MODE;
+  displayMode?: DisplayMode;
 };
 
 interface AppsState {
@@ -78,9 +75,7 @@ const appsSlice = createSlice({
         webViewUri: string;
         clientId: string;
         exchangedToken?: string;
-        displayMode?:
-          | typeof FULL_SCREEN_VIEWING_MODE
-          | typeof DEFAULT_VIEWING_MODE;
+        displayMode?: DisplayMode;
       }>
     ) => {
       const {

--- a/frontend/types/navigation.ts
+++ b/frontend/types/navigation.ts
@@ -24,4 +24,4 @@ export type MicroAppParams = {
   displayMode?: DisplayMode;
 };
 
-export type DisplayMode = typeof FULL_SCREEN_VIEWING_MODE | typeof DEFAULT_VIEWING_MODE;;
+export type DisplayMode = typeof FULL_SCREEN_VIEWING_MODE | typeof DEFAULT_VIEWING_MODE;

--- a/frontend/utils/bridge.ts
+++ b/frontend/utils/bridge.ts
@@ -28,6 +28,7 @@ export const TOPIC = {
   RESTORE_GOOGLE_DRIVE_BACKUP: "restore_google_drive_backup",
   GOOGLE_USER_INFO: "google_user_info",
   CHECK_GOOGLE_AUTH_STATE: "check_google_auth_state",
+  GO_BACK: "navigate_to_my_apps_screen",
 };
 
 // JavaScript code injected into the WebView to enable communication between

--- a/frontend/utils/bridge.ts
+++ b/frontend/utils/bridge.ts
@@ -28,7 +28,7 @@ export const TOPIC = {
   RESTORE_GOOGLE_DRIVE_BACKUP: "restore_google_drive_backup",
   GOOGLE_USER_INFO: "google_user_info",
   CHECK_GOOGLE_AUTH_STATE: "check_google_auth_state",
-  GO_BACK: "navigate_to_my_apps_screen",
+  CLOSE_WEBVIEW_FROM_MICROAPP: "close_webview"
 };
 
 // JavaScript code injected into the WebView to enable communication between


### PR DESCRIPTION
### Description 

- This PR introduces functionality to close the WebView when a Micro App explicitly triggers it. Previously, the WebView could only be closed via the back button in the Super App header.

### Related Issue

Closes (#40 )

https://github.com/user-attachments/assets/2ad67749-2b5a-48a2-ae15-f7d80e76d76b

