### PR TITLE
Feat : Add endpoint for retrieve app configs

### DIFF
--- a/backend/modules/database/db_functions.bal
+++ b/backend/modules/database/db_functions.bal
@@ -177,3 +177,19 @@ public isolated function deleteFcmToken(string fcmToken) returns ExecutionSucces
 
     return result.cloneWithType(ExecutionSuccessResult);
 }
+
+# Get an app configuration value from the database.
+#
+# + ConfigKey - The configuration key used to look up the value.
+# + return - boolean (`true` or `false`), or `error` if the configuration is not found or cannot be retrieved.
+public isolated function getAppConfigs(string ConfigKey) returns boolean|error {
+    AppConfigResponse result = check databaseClient->queryRow(getAppConfigsQuery(ConfigKey));
+    if result.Type == "boolean" {
+        if result.Value == "true" {
+            return true;
+        } else if result.Value == "false" {
+            return false;
+        }
+    }
+    return error("Failed to get AppConfig : " + ConfigKey);
+}

--- a/backend/modules/database/db_functions.bal
+++ b/backend/modules/database/db_functions.bal
@@ -20,7 +20,7 @@ import ballerina/sql;
 #
 # + groups - User's groups
 # + return - Array of MicroApp IDs or an error
-isolated function getMicroAppIdsByGroups(string[] groups) returns string[]|error {
+public isolated function getMicroAppIdsByGroups(string[] groups) returns string[]|error {
     stream<MicroAppId, sql:Error?> appIdStream = databaseClient->query(getMicroAppIdsByGroupsQuery(groups));
     string[] appIds = check from MicroAppId microAppId in appIdStream
         select microAppId.appId;

--- a/backend/modules/database/db_queries.bal
+++ b/backend/modules/database/db_queries.bal
@@ -220,3 +220,12 @@ public isolated function addFcmTokenQuery(string email, string fcmToken) returns
 public isolated function deleteFcmTokenQuery(string fcmToken) returns sql:ParameterizedQuery =>
     `DELETE FROM device_tokens WHERE fcm_token = ${fcmToken}`;
 
+# Query to retrieve an application configuration by key.
+#
+# + ConfigKey - The configuration key used to look up the value.
+# + return - A Query that selects the `Value` and `Type`fields from the `appconfig` table for the given `ConfigKey`.
+public isolated function getAppConfigsQuery(string ConfigKey) returns sql:ParameterizedQuery => `
+    SELECT Value, Type
+    FROM appconfig
+    WHERE ConfigKey = ${ConfigKey}
+`;

--- a/backend/modules/database/types.bal
+++ b/backend/modules/database/types.bal
@@ -162,3 +162,11 @@ public type FcmTokenResponse record {|
     # Total items for per page
     int itemsPerPage;
 |};
+
+# Response type for app config response.
+public type AppConfigResponse record {|
+    # Conflagration Value
+    string Value;
+    # Conflagration value Type
+    string Type;
+|};

--- a/backend/types.bal
+++ b/backend/types.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2025 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# App scope record type.
+public type AppScope record {|
+    # Micro-app id
+    string appId;
+    # Scopes for the micro-app
+    string scopes;
+|};
+
+# App scope record type.
+public type AppConfigResponse record {|
+    # Force Update Status
+    boolean isForceUpdate;
+    # Micro App Ids
+    string[] defaultMicroAppIds;
+    # Micro App Scopes
+    AppScope[] appScopes;
+|};


### PR DESCRIPTION
### Description
---
This PR introduces a new API endpoint to fetch application configuration details.
---

- Retrieve isForceUpdate status from the database.
- Retrieve default micro-app IDs based on user groups from the database.
- Retrieve app scopes (app ID and scopes) as configurable values.
- Returns response in the following format:

`{
  "isForceUpdate": true,
  "defaultMicroAppIds": [
    "MICRO_APP_ID_1",
    "MICRO_APP_ID_2"
  ],
  "appScopes": [
    {
      "appId": "appid1",
      "scopes": "scope1 scope2"
    },
    {
      "appId": "appid2",
      "scopes": "scope1"
    }
  ]
}`

--- closes #45