### PR TITLE
[Frontend] Chore :Use backend provided app scopes and add duplicate removal for user configurations

### DIFF
--- a/frontend/app/micro-app.tsx
+++ b/frontend/app/micro-app.tsx
@@ -128,7 +128,6 @@ const MicroApp = () => {
         if (!token) throw new Error("Token exchange failed");
         setToken(token);
         sendTokenToWebView(token);
-        console.log(token);
       } catch (error) {
         console.error("Token exchange error:", error);
       }

--- a/frontend/app/micro-app.tsx
+++ b/frontend/app/micro-app.tsx
@@ -53,7 +53,8 @@ import {
 import prompt from "react-native-prompt-android";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { WebView, WebViewMessageEvent } from "react-native-webview";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
+import { RootState } from "@/context/store";
 
 WebBrowser.maybeCompleteAuthSession();
 
@@ -72,6 +73,9 @@ const MicroApp = () => {
   const pendingTokenRequests: ((token: string) => void)[] = [];
   const [webUri, setWebUri] = useState<string>(DEVELOPER_APP_DEFAULT_URL);
   const colorScheme = useColorScheme();
+  const appScopes = useSelector(
+    (state: RootState) => state.appConfig.appScopes
+  );
   const styles = createStyles(colorScheme ?? "light");
   const isDeveloper: boolean = appId.includes("developer");
   const isTotp: boolean = appId.includes("totp");
@@ -118,11 +122,13 @@ const MicroApp = () => {
           clientId,
           exchangedToken,
           appId,
+          appScopes,
           logout
         );
         if (!token) throw new Error("Token exchange failed");
         setToken(token);
         sendTokenToWebView(token);
+        console.log(token);
       } catch (error) {
         console.error("Token exchange error:", error);
       }

--- a/frontend/constants/Constants.ts
+++ b/frontend/constants/Constants.ts
@@ -41,9 +41,6 @@ export const LIBRARY_ARTICLE_FALLBACK_IMAGE =
   process.env.EXPO_PUBLIC_LIBRARY_ARTICLE_FALLBACK_IMAGE ?? "";
 export const DEVELOPER_APP_DEFAULT_URL =
   process.env.EXPO_PUBLIC_DEVELOPER_APP_DEFAULT_URL ?? "";
-// Authenticator Micro App ID
-export const AUTHENTICATOR_APP_ID =
-  process.env.EXPO_PUBLIC_AUTHENTICATOR_APP_ID ?? "";
 export const GOOGLE_SCOPES = [
   "openid",
   "profile",

--- a/frontend/context/slices/userConfigSlice.ts
+++ b/frontend/context/slices/userConfigSlice.ts
@@ -15,6 +15,7 @@
 // under the License.
 import { BASE_URL, USER_CONFIGURATIONS } from "@/constants/Constants";
 import { apiRequest } from "@/utils/requestHandler";
+import { removeDuplicatesFromUserConfigs } from "@/utils/removeDuplicates";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
 
@@ -52,11 +53,16 @@ export const getUserConfigurations = createAsyncThunk(
       );
 
       if (response?.status === 200 && response?.data) {
+        // Remove duplicates from configValue arrays in response
+        const cleanedResponseData = removeDuplicatesFromUserConfigs(
+          response.data
+        );
+
         await AsyncStorage.setItem(
           USER_CONFIGURATIONS,
-          JSON.stringify(response.data)
+          JSON.stringify(cleanedResponseData)
         );
-        return response.data;
+        return cleanedResponseData;
       } else {
         return [];
       }

--- a/frontend/utils/removeDuplicates.ts
+++ b/frontend/utils/removeDuplicates.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2025 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import { UserConfig } from "@/context/slices/userConfigSlice";
+
+//Removes duplicate values from the configValue array in user configurations
+export const removeDuplicatesFromUserConfigs = (
+  userConfigs: UserConfig[]
+): UserConfig[] => {
+  return userConfigs.map((config) => {
+    if (!Array.isArray(config.configValue)) {
+      return config;
+    }
+
+    // Handle string arrays
+    if (
+      config.configValue.length > 0 &&
+      typeof config.configValue[0] === "string"
+    ) {
+      return {
+        ...config,
+        configValue: [...new Set(config.configValue as string[])],
+      };
+    }
+
+    // Handle AppArrangement arrays - remove duplicates based on the 'name' property
+    const arrangementArray = config.configValue as any[];
+    const uniqueArrangements = arrangementArray.filter(
+      (item, index, self) =>
+        index === self.findIndex((arr) => arr.name === item.name)
+    );
+
+    return {
+      ...config,
+      configValue: uniqueArrangements,
+    };
+  });
+};


### PR DESCRIPTION
# PR Description

This PR introduces improvements to how app scopes and user configurations are handled.

## Key Changes

### App Scopes
- Removed hardcoded scopes from the frontend.  
- Integrated app scopes retrieved from the backend.  
- Passed app scopes via Redux (`appConfig.appScopes`) for consistent access across the app.  
- Updated `tokenExchange` to use backend-provided scopes instead of static values.  

### User Configurations
- Implemented a utility `removeDuplicatesFromUserConfigs` to clean duplicate values in `configValue` arrays.  
- Ensured both string arrays and app arrangement arrays are deduplicated (based on `name` property).  
- Applied cleaned configuration data before storing in `AsyncStorage` and Redux state.  
---
Closes(#58)