### PR TITLE
[SuperApp Mobile] Update users search from a group

### DIFF
--- a/backend/modules/database/db_functions.bal
+++ b/backend/modules/database/db_functions.bal
@@ -167,7 +167,7 @@ public isolated function getFcmTokens(string[] emails, int startIndex) returns F
         fcmTokens: tokens,
         totalResults: countRecord.count,
         startIndex,
-        itemsPerPage: 'limit
+        itemsPerPage: countRecord.count > 'limit ? 'limit : countRecord.count
     };
 }
 

--- a/backend/modules/scim/types.bal
+++ b/backend/modules/scim/types.bal
@@ -26,53 +26,22 @@ type Oauth2Config record {|
     string[] scopes;
 |};
 
-# Request record for the SCIM group search request.
-public type GroupSearchRequest record {|
-    # The group name string used to query groups from the SCIM service
-    string filter;
-|};
-
-# Response record for the SCIM group search response.
-public type GroupSearchResponse record {|
-    # The total number of results that match the request
+# User search result.
+public type UserSearchResult record {|
+    # Total number of users
     int totalResults;
-    # The index of the first result returned 
+    # Starting index of the response
     int startIndex;
-    # The number of items returned per page
+    # Number of users returned in the response
     int itemsPerPage;
-    # The list of SCIM schema URIs 
-    string[] schemas;
-    # The array of group resources that match the search request
-    GroupResource[] Resources;
-|};
-
-# Record representing a SCIM group resource returned in a group search response.
-public type GroupResource record {|
-    # The unique identifier of the group
-    string id;
-    # The display name of the group
-    string displayName;
-    # The members that belong to the group
-    GroupMember[] members;
-    # Metadata about the group resource
-    GroupMeta meta;
-|};
-
-# Record representing a member of a SCIM group resource.
-public type GroupMember record {|
-    # The id of the member
-    string value;
-    # The email of the member
-    string display;
+    # List of group details
+    User[] Resources = [];
     json...;
 |};
 
-# Record representing metadata of a SCIM group resource.
-public type GroupMeta record {|
-    # The timestamp when the group resource was created
-    string created;
-    # The URI location of the group resource
-    string location;
-    # The timestamp when the group resource was last modified
-    string lastModified;
+# User.
+public type User record {|
+    # User name
+    string userName;
+    json...;
 |};

--- a/backend/modules/scim/utils.bal
+++ b/backend/modules/scim/utils.bal
@@ -14,16 +14,13 @@
 // specific language governing permissions and limitations
 // under the License. 
 
-# Calls the `searchInternalGroups` function, processes its response, and stores the emails in a string array.
-#
-# + group - The filter string used to search groups from the SCIM operations service
+# Gets the email addresses of users belonging to a specific group from the SCIM operations service.
+# 
+# + group - Filter used to search users of a group from the SCIM operations service
 # + return - An array of email strings, or an error if the operation fails
 public isolated function getGroupMemberEmails(string group) returns string[]|error {
-    GroupSearchResponse groupResponse = check searchInternalGroups(group);
-    if groupResponse.totalResults == 0 || groupResponse.Resources.length() == 0 {
-        return [];
-    }
-    return from GroupMember member in groupResponse.Resources[0].members
-        let string displayName = member.display
+    User[] users = check searchUsers(group);
+    return from User user in users
+        let string displayName = user.userName
         select displayName.startsWith(STORE_NAME) ? displayName.substring(STORE_NAME.length()) : displayName;
 }


### PR DESCRIPTION
## Description
+ Update users search by a group through `users/search` resource method apart from `groups/search` in the scim service.
+ Update pagination attribute in the fcm token response.