### PR TITLE
[Super App/ SecureStore] Use secure store for auth data and handle fresh installs

### DIFF
--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -20,7 +20,7 @@ import { restoreAuth } from "@/context/slices/authSlice";
 import { getUserConfigurations } from "@/context/slices/userConfigSlice";
 import { setUserInfo } from "@/context/slices/userInfoSlice";
 import { getVersions } from "@/context/slices/versionSlice";
-import { RootState, AppDispatch, persistor, store } from "@/context/store";
+import { AppDispatch, persistor, store } from "@/context/store";
 import { useColorScheme } from "@/hooks/useColorScheme";
 import { usePushNotificationHandler } from "@/hooks/usePushNotificationHandler";
 import { scheduleSessionNotifications } from "@/services/scheduledNotifications";
@@ -44,6 +44,7 @@ import { useCallback, useEffect, useState } from "react";
 import { Provider, useDispatch } from "react-redux";
 import { PersistGate } from "redux-persist/integration/react";
 import { restoreExchangedTokens } from "@/utils/exchangedTokenRehydrator";
+import { handleFreshInstall } from "@/utils/freshInstall";
 
 // Component to handle app initialization
 function AppInitializer({ onReady }: { onReady: () => void }) {
@@ -60,6 +61,7 @@ function AppInitializer({ onReady }: { onReady: () => void }) {
   useEffect(() => {
     const initialize = async () => {
       try {
+        await handleFreshInstall();
         const [savedApps, savedUserInfo] = await Promise.all([
           AsyncStorage.getItem(APPS),
           AsyncStorage.getItem(USER_INFO),

--- a/frontend/constants/Constants.ts
+++ b/frontend/constants/Constants.ts
@@ -89,6 +89,11 @@ export const DEFAULT_VIEWING_MODE = "default";
 
 // Keys for Secure Store
 export const LAST_SENT_FCM_TOKEN = "last_sent_fcm_token";
+export const ACCESS_TOKEN = "secure_access_token";
+export const REFRESH_TOKEN = "secure_refresh_token";
+export const ID_TOKEN = "secure_id_token";
+export const EXPIRES_AT_KEY = "secure_expires_at";
+export const AUTH_EMAIL_KEY = "secure_auth_email";
 
 // Notifee Channel ID and Name
 export const NOTIFICATION_CHANNEL_ID =

--- a/frontend/context/slices/userConfigSlice.ts
+++ b/frontend/context/slices/userConfigSlice.ts
@@ -57,10 +57,15 @@ export const getUserConfigurations = createAsyncThunk(
         const cleanedResponseData = removeDuplicatesFromUserConfigs(
           response.data
         );
+        // Persist without email
+        const toCache = cleanedResponseData.map((config: UserConfig) => {
+          const { email, ...rest } = config;
+          return rest;
+        });
 
         await AsyncStorage.setItem(
           USER_CONFIGURATIONS,
-          JSON.stringify(cleanedResponseData)
+          JSON.stringify(toCache)
         );
         return cleanedResponseData;
       } else {

--- a/frontend/context/store.ts
+++ b/frontend/context/store.ts
@@ -38,12 +38,6 @@ const stripExchangedTokens = createTransform(
   { whitelist: ["apps"] }
 );
 
-const authPersistConfig = {
-  key: "auth",
-  storage: AsyncStorage,
-  whitelist: ["auth"],
-};
-
 const appsPersistConfig = {
   key: "apps",
   storage: AsyncStorage,
@@ -70,7 +64,7 @@ const appConfigPersistConfig = {
 };
 
 const appReducerCombined = combineReducers({
-  auth: persistReducer(authPersistConfig, authReducer),
+  auth: authReducer,
   apps: persistReducer(appsPersistConfig, appReducer),
   userConfig: persistReducer(userConfigPersistConfig, userConfigReducer),
   version: versionReducer,

--- a/frontend/services/authService.ts
+++ b/frontend/services/authService.ts
@@ -16,7 +16,6 @@
 import { AUTH_CONFIG } from "@/config/authConfig";
 import {
   APPS,
-  AUTH_DATA,
   CLIENT_ID,
   LOGOUT_URL,
   REDIRECT_URI,
@@ -35,6 +34,12 @@ import { jwtDecode } from "jwt-decode";
 import { Alert } from "react-native";
 import { logout as appLogout, AuthorizeResult } from "react-native-app-auth";
 import { clearAllExchangedTokens } from "@/utils/exchangedTokenStore";
+import {
+  saveAuthDataToSecureStore,
+  loadAuthDataFromSecureStore,
+  clearAuthDataFromSecureStore,
+  SecureAuthData,
+} from "@/utils/authTokenStore";
 
 const GRANT_TYPE_AUTHORIZATION_CODE = "authorization_code";
 const GRANT_TYPE_REFRESH_TOKEN = "refresh_token";
@@ -99,7 +104,7 @@ export const getAccessToken = async (
           expiresAt: exp * MILLISECONDS_IN_A_SECOND,
         };
 
-        await AsyncStorage.setItem(AUTH_DATA, JSON.stringify(authData)); // Persist data
+        await saveAuthDataToSecureStore(authData as SecureAuthData); // Persist data
         return authData;
       }
     } catch (err) {
@@ -119,13 +124,13 @@ export const refreshAccessToken = async (
 
   refreshPromise = (async () => {
     try {
-      const storedData = await AsyncStorage.getItem(AUTH_DATA);
+      const storedData = await loadAuthDataFromSecureStore();
       if (!storedData) {
         refreshPromise = null;
         return null;
       }
 
-      const authData: AuthData = JSON.parse(storedData);
+      const authData: AuthData = storedData;
       if (!authData.refreshToken) {
         refreshPromise = null;
         return null;
@@ -175,7 +180,7 @@ export const refreshAccessToken = async (
           expiresAt: exp * MILLISECONDS_IN_A_SECOND,
         };
 
-        await AsyncStorage.setItem(AUTH_DATA, JSON.stringify(updatedAuthData));
+        await saveAuthDataToSecureStore(updatedAuthData as SecureAuthData);
 
         refreshPromise = null;
         return updatedAuthData;
@@ -207,12 +212,12 @@ export const refreshAccessToken = async (
 export const logout = async () => {
   try {
     // Retrieve stored authentication data
-    const storedData = await AsyncStorage.getItem(AUTH_DATA);
-    if (!storedData) {
+    const secureData = await loadAuthDataFromSecureStore();
+    if (!secureData) {
       console.error("No stored authentication data found.");
       return;
     }
-    const { idToken } = JSON.parse(storedData) as { idToken?: string };
+    const idToken = secureData?.idToken;
     const appsJson = await AsyncStorage.getItem(APPS); // capture appIds BEFORE clearing APPS
     const appIds = appsJson ? (JSON.parse(appsJson) as { appId: string }[]).map(a => a.appId) : [];
 
@@ -226,7 +231,7 @@ export const logout = async () => {
     if (!idToken) {
       console.warn("No idToken found. Performing local logout only.");
       await clearAllExchangedTokens(appIds);
-      await AsyncStorage.removeItem(AUTH_DATA);
+      await clearAuthDataFromSecureStore();
       await AsyncStorage.removeItem(APPS);
       await AsyncStorage.removeItem(USER_INFO);
       return;
@@ -234,11 +239,11 @@ export const logout = async () => {
 
     // Perform logout request
     await appLogout(AUTH_CONFIG, {
-      idToken: idToken,
+      idToken,
       postLogoutRedirectUrl: REDIRECT_URI,
     });
     await clearAllExchangedTokens(appIds);
-    await AsyncStorage.removeItem(AUTH_DATA);
+    await clearAuthDataFromSecureStore();
     await AsyncStorage.removeItem(APPS);
     await AsyncStorage.removeItem(USER_INFO);
   } catch (error) {
@@ -253,8 +258,8 @@ export const logout = async () => {
 
 // Restore auth data form secure storage
 export const loadAuthData = async (): Promise<AuthData | null> => {
-  const storedData = await AsyncStorage.getItem(AUTH_DATA);
-  return storedData ? JSON.parse(storedData) : null;
+  const secureData = await loadAuthDataFromSecureStore();
+  return secureData ? (secureData as AuthData) : null;
 };
 
 // token exchange
@@ -279,13 +284,13 @@ export const tokenExchange = async (
     }
 
     // Retrieve stored authentication data
-    const storedData = await AsyncStorage.getItem(AUTH_DATA);
-    if (!storedData) {
+    const secureData = await loadAuthDataFromSecureStore();
+    if (!secureData?.accessToken) {
       console.error("No stored authentication data found.");
       return null;
     }
 
-    let { accessToken } = JSON.parse(storedData) as { accessToken?: string };
+    let accessToken = secureData.accessToken;
     if (!accessToken) {
       console.error("No access token found in stored authentication data.");
       return null;
@@ -407,11 +412,11 @@ export const processNativeAuthResult = async (
         accessToken: authResult.accessToken,
         refreshToken: authResult.refreshToken,
         idToken: authResult.idToken,
-        email: email,
+        email,
         expiresAt: exp * MILLISECONDS_IN_A_SECOND,
       };
 
-      await AsyncStorage.setItem(AUTH_DATA, JSON.stringify(authData));
+      await saveAuthDataToSecureStore(authData as SecureAuthData);
       return authData;
     } else {
       console.error("Missing required tokens in auth result");

--- a/frontend/services/userConfigService.ts
+++ b/frontend/services/userConfigService.ts
@@ -31,11 +31,12 @@ export const UpdateUserConfiguration = async (
   onLogout: () => Promise<void>
 ) => {
   try {
+    type CachedUserConfig = Omit<UserConfig, "email">;
     // Get the latest state directly from AsyncStorage each time
     const storedUserConfigsJson = await AsyncStorage.getItem(
       USER_CONFIGURATIONS
     );
-    let storedUserConfigs: UserConfig[] = storedUserConfigsJson
+    let storedUserConfigs: CachedUserConfig[] = storedUserConfigsJson
       ? JSON.parse(storedUserConfigsJson)
       : [];
 
@@ -52,7 +53,6 @@ export const UpdateUserConfiguration = async (
         {
           configKey: APP_LIST_CONFIG_KEY,
           configValue: [],
-          email,
           isActive: 1,
         },
       ];
@@ -89,6 +89,12 @@ export const UpdateUserConfiguration = async (
       USER_CONFIGURATIONS,
       JSON.stringify(updatedUserConfigs)
     );
+    const state = store.getState();
+    const email = state.auth.email;
+    if (!email) {
+      console.error("User email not found in auth state.");
+      return false;
+    }
 
     const response = await apiRequest(
       {
@@ -97,7 +103,7 @@ export const UpdateUserConfiguration = async (
         data: {
           configKey: APP_LIST_CONFIG_KEY,
           configValue: updatedConfigValue,
-          email: appUserConfigs.email,
+          email,
           isActive: appUserConfigs.isActive,
         },
       },

--- a/frontend/utils/authTokenStore.ts
+++ b/frontend/utils/authTokenStore.ts
@@ -1,0 +1,74 @@
+// Copyright (c) 2025 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import * as SecureStore from "expo-secure-store";
+import {
+  ACCESS_TOKEN,
+  REFRESH_TOKEN,
+  ID_TOKEN,
+  EXPIRES_AT_KEY,
+  AUTH_EMAIL_KEY,
+} from "@/constants/Constants";
+
+export type SecureAuthData = {
+  accessToken: string;
+  refreshToken: string;
+  idToken: string;
+  email?: string;
+  expiresAt: number;
+};
+
+export async function saveAuthDataToSecureStore(authData: SecureAuthData) {
+  await Promise.all([
+    SecureStore.setItemAsync(ACCESS_TOKEN, authData.accessToken),
+    SecureStore.setItemAsync(REFRESH_TOKEN, authData.refreshToken),
+    SecureStore.setItemAsync(ID_TOKEN, authData.idToken),
+    SecureStore.setItemAsync(EXPIRES_AT_KEY, String(authData.expiresAt)),
+    authData.email
+      ? SecureStore.setItemAsync(AUTH_EMAIL_KEY, authData.email)
+      : SecureStore.deleteItemAsync(AUTH_EMAIL_KEY),
+  ]);
+}
+
+export async function loadAuthDataFromSecureStore(): Promise<SecureAuthData | null> {
+  const [accessToken, refreshToken, idToken, expiresAtStr, email] =
+    await Promise.all([
+      SecureStore.getItemAsync(ACCESS_TOKEN),
+      SecureStore.getItemAsync(REFRESH_TOKEN),
+      SecureStore.getItemAsync(ID_TOKEN),
+      SecureStore.getItemAsync(EXPIRES_AT_KEY),
+      SecureStore.getItemAsync(AUTH_EMAIL_KEY),
+    ]);
+
+  if (!accessToken || !refreshToken || !idToken || !expiresAtStr) return null;
+
+  return {
+    accessToken,
+    refreshToken,
+    idToken,
+    email: email || undefined,
+    expiresAt: Number(expiresAtStr),
+  };
+}
+
+export async function clearAuthDataFromSecureStore() {
+  await Promise.all([
+    SecureStore.deleteItemAsync(ACCESS_TOKEN),
+    SecureStore.deleteItemAsync(REFRESH_TOKEN),
+    SecureStore.deleteItemAsync(ID_TOKEN),
+    SecureStore.deleteItemAsync(EXPIRES_AT_KEY),
+    SecureStore.deleteItemAsync(AUTH_EMAIL_KEY),
+  ]);
+}

--- a/frontend/utils/freshInstall.ts
+++ b/frontend/utils/freshInstall.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2025 WSO2 LLC. (https://www.wso2.com).
+//
+// WSO2 LLC. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as SecureStore from "expo-secure-store";
+import {
+  ACCESS_TOKEN,
+  REFRESH_TOKEN,
+  ID_TOKEN,
+  EXPIRES_AT_KEY,
+  AUTH_EMAIL_KEY,
+} from "@/constants/Constants";
+
+const INSTALL_MARKER = "install_marker_v1";
+/**
+ * Wipes SecureStore only on a true fresh install using an AsyncStorage “install marker”.
+ * Used because SecureStore can persist across app reinstalls, leaving stale auth secrets.
+ * The AsyncStorage marker is a simple, widely used pattern in RN/Expo to detect fresh installs.
+ * Ensures a clean, secure baseline before restoring auth or registering push tokens.
+ */
+export async function handleFreshInstall() {
+  const marker = await AsyncStorage.getItem(INSTALL_MARKER);
+  if (marker) return; // not a fresh install
+
+  try {
+    // Wipe all auth secrets that might have survived uninstall in SecureStore
+    await Promise.all([
+      SecureStore.deleteItemAsync(ACCESS_TOKEN),
+      SecureStore.deleteItemAsync(REFRESH_TOKEN),
+      SecureStore.deleteItemAsync(ID_TOKEN),
+      SecureStore.deleteItemAsync(EXPIRES_AT_KEY),
+      SecureStore.deleteItemAsync(AUTH_EMAIL_KEY),
+    ]);
+  } catch (e) {
+    console.warn("failed to clear SecureStore", e);
+  } finally {
+    await AsyncStorage.setItem(INSTALL_MARKER, "1");
+  }
+}

--- a/frontend/utils/performLogout.ts
+++ b/frontend/utils/performLogout.ts
@@ -13,7 +13,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-import { APPS, AUTH_DATA, USER_INFO } from "@/constants/Constants";
+import { APPS, USER_INFO } from "@/constants/Constants";
 import { ScreenPaths } from "@/constants/ScreenPaths";
 import { resetAll } from "@/context/slices/authSlice";
 import { clearDeviceState } from "@/context/slices/deviceSlice";
@@ -24,6 +24,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import { createAsyncThunk } from "@reduxjs/toolkit";
 import { router } from "expo-router";
 import { Alert } from "react-native";
+import { clearAuthDataFromSecureStore } from "@/utils/authTokenStore";
 
 // Logout user
 export const performLogout = createAsyncThunk(
@@ -31,11 +32,11 @@ export const performLogout = createAsyncThunk(
   async (_, { dispatch }) => {
     try {
       await logout(); // Call Asgardeo logout
+      await clearAuthDataFromSecureStore();
       await persistor.purge(); // Clear redux-persist storage
       dispatch(resetAll()); // Reset Redux state completely
       dispatch(clearDeviceState()); // Reset device state
 
-      await AsyncStorage.removeItem(AUTH_DATA);
       await AsyncStorage.removeItem(APPS);
       await AsyncStorage.removeItem(USER_INFO);
       // Clear all scheduled notifications and stored notification data

--- a/frontend/utils/requestHandler.ts
+++ b/frontend/utils/requestHandler.ts
@@ -13,12 +13,11 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
-import { AUTH_DATA } from "@/constants/Constants";
 import { refreshAccessToken } from "@/services/authService";
 import axios, { AxiosRequestConfig } from "axios";
 import { jwtDecode } from "jwt-decode";
 import dayjs from "dayjs";
-import AsyncStorage from "@react-native-async-storage/async-storage";
+import { loadAuthDataFromSecureStore } from "@/utils/authTokenStore";
 
 // General API request handler
 export const apiRequest = async (
@@ -81,7 +80,7 @@ const isAccessTokenExpired = (accessToken: string): boolean => {
 
 // Helper function to get the stored access token
 const getAccessToken = async (): Promise<string> => {
-  const storedData = await AsyncStorage.getItem(AUTH_DATA);
-  if (!storedData) return "";
-  return JSON.parse(storedData)?.accessToken || "";
+  const secure = await loadAuthDataFromSecureStore();
+  if (!secure) return "";
+  return secure?.accessToken || "";
 };


### PR DESCRIPTION
**move all auth tokens to SecureStore, strip from redux-persist, and rehydrate per-microapp tokens on startup**

Purpose

- Eliminate token leakage to AsyncStorage/redux-persist.
- Ensure tokens survive app restarts safely and are refreshed correctly.
- freshInstall 

what changed

- access/refresh/id tokens + expiresAt + email saved via authTokenStore (expo-secure-store).
- No redux-persist for auth; redux state is hydrated at runtime from SecureStore (restoreAuth).
- On startup we rehydrate per-microapp tokens from SecureStore (restoreExchangedTokens).
- UserConfig cache without PII
- When fetching /users/user-configs, we strip email before writing to AsyncStorage.
- When posting updates, we read email from runtime auth (which ultimately comes from SecureStore) instead of AsyncStorage.
- where email now comes from, state.auth.email (set by restoreAuth() which loads from SecureStore).
- SecureStore can survive app reinstalls, leaving stale tokens and emails. The fresh-install marker in AsyncStorage detects a first run and wipes SecureStore, preventing ghost sessions, token leaks, and push-token mismatches.